### PR TITLE
fix the problem that some hive databases do not display.

### DIFF
--- a/lib/shib/engine.js
+++ b/lib/shib/engine.js
@@ -107,7 +107,7 @@ Engine.prototype.databases = function(callback){
       var len = dbnamelist.length;
       for (var i = 0 ; i < len ; i++) {
         if (dbnamelist[i] === self._default_dbname) {
-          dbnamelist.splice(i);
+          dbnamelist.splice(i, 1);
           break;
         }
       }


### PR DESCRIPTION
for example, there are "a", "b", "c", "default", "e", "f"  as hive databases.
in this case, "e" and "f" do not display.

I think that it is correct to use splice(index, howmany).

for example,

var dbnamelist = ["a", "b", "c", "default", "e", "f"];
var len = dbnamelist.length;
for (var i = 0 ; i < len ; i++) {
  if (dbnamelist[i] === "default") {
    dbnamelist.splice(i);
    break;
  }
}
dbnamelist.unshift("default");
//[ 'default', 'a', 'b', 'c']

var dbnamelist = ["a", "b", "c", "default", "e", "f"];
var len = dbnamelist.length;
for (var i = 0 ; i < len ; i++) {
  if (dbnamelist[i] === "default") {
    dbnamelist.splice(i, 1);
    break;
  }
}
dbnamelist.unshift("default");
//[ 'default', 'a', 'b', 'c', 'e', 'f' ]
