### PR TITLE
avoid TypeError: Cannot read property 'queryid' of null

### DIFF
--- a/app.js
+++ b/app.js
@@ -361,6 +361,11 @@ app.post('/delete', function(req, res){
 app.get('/query/:queryid', function(req, res){
   shibclient(req).query(req.params.queryid, function(err, query){
     if (err) { error_handle(req, res, err); this.end(); return; }
+    if (query === null) {
+      res.send('query not found', 404);
+      this.end();
+      return;
+    }
     res.send(pseudo_query_data(query));
     this.end();
   });

--- a/lib/shib/localdiskstore.js
+++ b/lib/shib/localdiskstore.js
@@ -150,7 +150,7 @@ LocalDiskStore.prototype.query = function(queryid, callback){
   var sql = 'SELECT id,datetime,engine,dbname,expression,state,resultid,result FROM queries WHERE id=?';
   this.db.get(sql, [queryid], function(err,row){
     if (err) { callback(err); return; }
-    if (!row) { callback(new Error("queryid=" + queryid + " is not found in DB."), null); return; }
+    if (!row) { callback(null, null); return; }
     callback(null, new Query(row));
   });
 };

--- a/lib/shib/localdiskstore.js
+++ b/lib/shib/localdiskstore.js
@@ -150,7 +150,7 @@ LocalDiskStore.prototype.query = function(queryid, callback){
   var sql = 'SELECT id,datetime,engine,dbname,expression,state,resultid,result FROM queries WHERE id=?';
   this.db.get(sql, [queryid], function(err,row){
     if (err) { callback(err); return; }
-    if (!row) { callback(null, null); return; }
+    if (!row) { callback(new Error("queryid=" + queryid + " is not found in DB."), null); return; }
     callback(null, new Query(row));
   });
 };


### PR DESCRIPTION
If you access shin API with queryid which does not exists in DB, TypeError occurs.

If this patch is applied, the result is the following. Shib does not shutdown.

curl -s http://shib.server.local:3000/query/aaaaaaaa

```
Tue Mar 03 2015 12:17:43 GMT+0900 (JST) [INFO] : Starting shib.
Tue Mar 03 2015 12:17:47 GMT+0900 (JST) [ERROR] : Error in app, [Error: queryid=aaaaaaaa is not found in DB.]
Tue Mar 03 2015 12:17:47 GMT+0900 (JST) [ERROR] : Error: queryid=aaaaaaaa is not found in DB.
    at Statement.<anonymous> (/.../shib/lib/shib/localdiskstore.js:153:26)
```

ref:https://github.com/tagomoris/shib/issues/25
