### PR TITLE
order by datetime

### DIFF
--- a/lib/shib/localdiskstore.js
+++ b/lib/shib/localdiskstore.js
@@ -193,7 +193,7 @@ LocalDiskStore.prototype.deleteQuery = function(queryid, callback){
 };
 
 LocalDiskStore.prototype.recentQueries = function(num, callback){
-  var sql = 'SELECT id,datetime,engine,dbname,expression,state,resultid,result FROM queries WHERE scheduled IS NULL ORDER BY id DESC LIMIT ' + parseInt(num);
+  var sql = 'SELECT id,datetime,engine,dbname,expression,state,resultid,result FROM queries WHERE scheduled IS NULL ORDER BY datetime DESC LIMIT ' + parseInt(num);
   var db = this.db;
   this.db.all(sql, function(err, rows){
     if (err) { callback(err); return; }


### PR DESCRIPTION
I think that history tab at shib should show query histories in datetime order.