### PR TITLE
allow WITH clause in a query

### DIFF
--- a/lib/shib/query.js
+++ b/lib/shib/query.js
@@ -186,7 +186,7 @@ Query.checkQueryString = function(querystring){
   }
   // query type of create/drop/..../alter/load/insert/explain too many query types!!!
   // white list now...
-  if (/^\s*select .* from .+$/i.exec(removeNewLinesAndComments(querystring))){
+  if (/^\s*(with .*)?\s*select .* from .+$/i.exec(removeNewLinesAndComments(querystring))){
     return;
   }
   throw new InvalidQueryError("Invalid query type. Allowed methods: 'SELECT'.");

--- a/test/t_query.js
+++ b/test/t_query.js
@@ -50,6 +50,8 @@ module.exports = testCase({
     test.throws(function(){Query.checkQueryString("insert overwrite into hoge\nselect col1,col2 from hoge where moge='pos'");});
     test.doesNotThrow(function(){Query.checkQueryString("select field1,field2,count(*) as cnt from hoge_table where yyyymmdd=today()");});
     test.doesNotThrow(function(){Query.checkQueryString(" select field1,field2,count(*) as cnt from hoge_table where yyyymmdd=today()");});
+    test.doesNotThrow(function(){Query.checkQueryString("with tbl as (select id from source where id > 10) select count(id) from tbl");});
+    test.doesNotThrow(function(){Query.checkQueryString(" with tbl as (select id from source where id > 10) select count(id) from tbl");});
     test.throws(function(){
       Query.checkQueryString("select field1,field2,count(*) as cnt from hoge_table where yyyymmdd=today(); drop table hoge_table");
     });


### PR DESCRIPTION
- modify query validation regular expression to allow WITH before select
- add two tests for WITH clause and checked other query validation tests don't fail