### PR TITLE
add query null check

### DIFF
--- a/app.js
+++ b/app.js
@@ -581,7 +581,7 @@ app.get('/download/tsv/:resultid', function(req, res){
 
     if (query === null) {
       res.send(null);
-      res.end();
+      this.end();
       return;
     }
 
@@ -620,7 +620,7 @@ app.get('/download/csv/:resultid', function(req, res){
 
     if (query === null) {
       res.send(null);
-      res.end();
+      this.end();
       return;
     }
 

--- a/app.js
+++ b/app.js
@@ -441,6 +441,11 @@ function pseudo_status(query_state){
 app.get('/status/:queryid', function(req, res){
   shibclient(req).query(req.params.queryid, function(err, query){
     if (err) { error_handle(req, res, err); this.end(); return; }
+    if (query === null) {
+      res.send('query not found', 404);
+      this.end();
+      return;
+    }
     res.send(pseudo_status(query.state));
     this.end();
   });
@@ -487,6 +492,11 @@ app.get('/lastresult/:queryid', function(req, res){
 app.get('/result/:resultid', function(req, res){
   shibclient(req).getQueryByResultId(req.params.resultid, function(err, query){
     if (err) { error_handle(req, res, err); this.end(); return; }
+    if (query === null) {
+      res.send('query not found', 404);
+      this.end();
+      return;
+    }
     res.send(pseudo_result_data(query));
     this.end();
   });
@@ -569,6 +579,12 @@ app.get('/download/tsv/:resultid', function(req, res){
   shibclient(req).getQueryByResultId(req.params.resultid, function(err, query){
     if (err) { error_handle(req, res, err); this.end(); return; }
 
+    if (query === null) {
+      res.send(null);
+      res.end();
+      return;
+    }
+
     res.attachment(req.params.resultid + '.tsv');
     res.set('X-Shib-Query-ID', query.queryid);
     res.set('X-Shib-Result-ID', query.resultid);
@@ -601,6 +617,12 @@ app.get('/download/tsv/:resultid', function(req, res){
 app.get('/download/csv/:resultid', function(req, res){
   shibclient(req).getQueryByResultId(req.params.resultid, function(err, query){
     if (err) { error_handle(req, res, err); this.end(); return; }
+
+    if (query === null) {
+      res.send(null);
+      res.end();
+      return;
+    }
 
     res.attachment(req.params.resultid + '.csv');
     res.set('X-Shib-Query-ID', query.queryid);


### PR DESCRIPTION
If you access shib API with non-existence queryid/resultid , the following TypeError occurs.

For, exapmle, if you access /download/tsv/:resultid with non-existence resultid, the following TypeError occurs.

/.../shib/app.js:573
    res.set('X-Shib-Query-ID', query.queryid);
                                    ^
TypeError: Cannot read property 'queryid' of null
    at null.<anonymous> (/.../shib/app.js:573:37)
    at /.../shib/lib/shib/client.js:257:14
    at Statement.<anonymous> (/.../shib/lib/shib/localdiskstore.js:162:17)