### PR TITLE
avoid TypeError: Cannot read property 'result' of null

### DIFF
--- a/app.js
+++ b/app.js
@@ -510,6 +510,11 @@ app.post('/results', function(req, res){
   var fetchers = (req.body.ids || []).map(function(resultid){
     return function(cb){
       client.getQueryByResultId(resultid, function(err, query){
+        if (query === null) {
+          res.send('query not found', 404);
+          this.end();
+          return;
+        }
         if (err) { cb(err); return; }
         cb(null, pseudo_result_data(query));
       });


### PR DESCRIPTION
avoid the following error
```
/.../shib/app.js:470
  var r = query.result;
               ^
TypeError: Cannot read property 'result' of null
    at pseudo_result_data (/.../shib/app.js:470:16)
    at null.<anonymous> (/.../shib/app.js:514:18)
    at /.../shib/lib/shib/client.js:258:14
    at Statement.<anonymous> (/.../shib/lib/shib/localdiskstore.js:162:17)
```