### PR TITLE
fix partition expansion error

### DIFF
--- a/lib/shib/client.js
+++ b/lib/shib/client.js
@@ -396,7 +396,7 @@ Client.prototype.partitions = function(engineLabel, dbname, tablename, callback)
       return node;
     };
 
-    data.forEach(function(partition){
+    (data || []).forEach(function(partition){
       create_node(partition);
     });
     callback.apply(client, [error, partition_nodes]);


### PR DESCRIPTION
if you try to expand partition on non partition hive table, the following error occurs.

/.../shib/node_modules/node-thrift/lib/thrift/connection.js:94
        throw e;
              ^
TypeError: Cannot call method 'forEach' of undefined
    at /.../shib/lib/shib/client.js:399:10
    at /.../shib/lib/shib/engines/hiveserver2/index.js:195:16
    at /.../shib/lib/shib/engines/hiveserver2/index.js:295:11
    at client._reqs.(anonymous function) (/.../shib/node_modules/node-thrift/lib/thrift/connection.js:84:11)
    at Object.TCLIServiceClient.recv_ExecuteStatement (/.../shib/lib/shib/engines/hiveserver2/TCLIService.js:1878:12)
    at /.../shib/node_modules/node-thrift/lib/thrift/connection.js:87:37
    at Socket.<anonymous> (/.../shib/node_modules/node-thrift/lib/thrift/transport.js:185:5)
    at Socket.emit (events.js:95:17)
    at Socket.<anonymous> (_stream_readable.js:765:14)
    at Socket.emit (events.js:92:17)