### PR TITLE
kill first

### DIFF
--- a/lib/shib/client.js
+++ b/lib/shib/client.js
@@ -419,11 +419,6 @@ Client.prototype.describe = function(engineLabel, dbname, tablename, callback){
 Client.prototype.giveup = function(query, callback){
   var client = this;
 
-  query.markAsExecuted({message: 'specified as "give up"'});
-  client.updateQuery(query);
-  if (callback)
-    callback.apply(client, [null, query]);
-
   if (! query.engine){
     client.end(); // self close after half close
     return;
@@ -439,6 +434,7 @@ Client.prototype.giveup = function(query, callback){
   engine.status(query.queryid, function(err, jobdata){
     if (err){ // engine doesn't support 'status' or errors with other reason
       // cannot kill with no status information
+      error_callback('giveup', client, callback, err)
       client.end(); // self close after half close
       return;
     }
@@ -447,6 +443,12 @@ Client.prototype.giveup = function(query, callback){
         if (err) {
           client.logger.error("Error on killing job", {jobid: jobdata.jobid, error: err});
         }
+
+        query.markAsExecuted({message: 'specified as "give up"'});
+        client.updateQuery(query);
+        if (callback)
+          callback.apply(client, [null, query]);
+
         client.end(); // self close after half close
       });
     }


### PR DESCRIPTION
If yarn map reduce heavy job is submitted from shib, such a job can't be submitted soon as map reduce job.
It takes a long time to submit a job as map reduce.

As the result, If you giveup the query, although shib DB is only update, job is not killed.

So, kill map reduce job and then update shib DB.