### PR TITLE
fetch starts when result data is prepared

### DIFF
--- a/lib/shib/engines/presto/index.js
+++ b/lib/shib/engines/presto/index.js
@@ -126,9 +126,9 @@ Executer.prototype.execute = function(jobname, dbname, query, callback){
   };
   var columns_callback = function(e, columns){
     fetcher._cache.schema = columns;
-    fetcher._hasResults = true;
   };
   var data_callback = function(e, data){
+    fetcher._hasResults = true;
     var buf = []
       , len = data.length;
     for ( var i = 0 ; i < len ; i++ ) {


### PR DESCRIPTION
fix the following error

```
/.../shib/lib/shib/engine.js:332
            if (rows === null || rows.length < 1 || (rows.length == 1 && rows[
                                     ^
TypeError: Cannot read property 'length' of undefined
    at /.../shib/lib/shib/engine.js:332:38
    at fill [as _onTimeout] (/.../shib/lib/shib/engines/presto/index.js:243:29)
    at Timer.listOnTimeout [as ontimeout] (timers.js:112:15)
```

This error occurs when presto query is cancelled through Web UI before it is completed.

It is possible to column information before presto query is completed.

So, the error occurs because fill method starts although presto query error occurs.