### PR TITLE
Kill last

### DIFF
--- a/lib/shib/client.js
+++ b/lib/shib/client.js
@@ -419,6 +419,11 @@ Client.prototype.describe = function(engineLabel, dbname, tablename, callback){
 Client.prototype.giveup = function(query, callback){
   var client = this;
 
+  query.markAsExecuted({message: 'specified as "give up"'});
+  client.updateQuery(query);
+  if (callback)
+    callback.apply(client, [null, query]);
+
   if (! query.engine){
     client.end(); // self close after half close
     return;
@@ -434,7 +439,6 @@ Client.prototype.giveup = function(query, callback){
   engine.status(query.queryid, function(err, jobdata){
     if (err){ // engine doesn't support 'status' or errors with other reason
       // cannot kill with no status information
-      error_callback('giveup', client, callback, err)
       client.end(); // self close after half close
       return;
     }
@@ -443,12 +447,6 @@ Client.prototype.giveup = function(query, callback){
         if (err) {
           client.logger.error("Error on killing job", {jobid: jobdata.jobid, error: err});
         }
-
-        query.markAsExecuted({message: 'specified as "give up"'});
-        client.updateQuery(query);
-        if (callback)
-          callback.apply(client, [null, query]);
-
         client.end(); // self close after half close
       });
     }

--- a/lib/shib/client.js
+++ b/lib/shib/client.js
@@ -439,6 +439,7 @@ Client.prototype.giveup = function(query, callback){
   engine.status(query.queryid, function(err, jobdata){
     if (err){ // engine doesn't support 'status' or errors with other reason
       // cannot kill with no status information
+      error_callback('giveup', client, callback, err);
       client.end(); // self close after half close
       return;
     }


### PR DESCRIPTION
I understand that killing job at first increases maintainance cost.

Although I revert kill first commit, I add giveup error message.

So, user can notice if job is not killed actually.

