### PR TITLE
http_basic_auth failed

### DIFF
--- a/lib/shib/auth/http_basic_auth.js
+++ b/lib/shib/auth/http_basic_auth.js
@@ -28,7 +28,7 @@ var Auth = exports.Auth = function(args, logger){
 
   this._url = parsed.href || args.url;
   this._method = args.method || 'GET';
-  this._host = args.host || parsed.host;
+  this._hostname = args.host || parsed.hostname;
   this._port = args.port || parsed.port || 80;
   this._path = args.path || '/'; // including query string
 
@@ -37,7 +37,7 @@ var Auth = exports.Auth = function(args, logger){
   if (protocol === 'https' || protocol === 'https:')
     this._client = https;
 
-  if (! this._host || ! this._path)
+  if (! this._hostname || ! this._path)
     throw "basic auth target host/path not speicifed";
 
   this._acl_config = args.access_control;
@@ -54,7 +54,7 @@ Auth.prototype.check = function(req, callback) {
 
   var auth_string = username + ':' + password;
   var options = {
-    host: this._host,
+    hostname: this._hostname,
     port: this._port,
     method: this._method,
     path: this._path,


### PR DESCRIPTION
Using `http_basic_auth` as authentication, shib occure error when send auth to auth server:
```
Thu Mar 31 2016 03:12:22 GMT-0700 (PDT) [ERROR] : Error in app, { [Error: getaddrinfo ENOTFOUND] code: 'ENOT
FOUND', errno: 'ENOTFOUND', syscall: 'getaddrinfo' }
Thu Mar 31 2016 03:12:22 GMT-0700 (PDT) [ERROR] : Error: getaddrinfo ENOTFOUND
    at errnoException (dns.js:37:11)
    at Object.onanswer [as oncomplete] (dns.js:126:16)
```

auth in `config.js`:
```
auth: {
    type: 'http_basic_auth',
    require_always: true,
    url: 'http://127.0.0.1:8002/',
    realm: '@xxx.com'
}
```

After check documents of `url` and `http` module:
- [url.parse](https://nodejs.org/api/url.html#url_url_parse_urlstr_parsequerystring_slashesdenotehost): host will be used in place of hostname and port.
- [http.request](https://nodejs.org/api/http.html#http_http_request_options_callback) host: A domain name or IP address of the server to issue the request to. Defaults to 'localhost'.

eg:
```
> url.parse('http://127.0.0.1:8002');
Url {
  protocol: 'http:',
  slashes: true,
  auth: null,
  host: '127.0.0.1:8002',
  port: '8002',
  hostname: '127.0.0.1',
  hash: null,
  search: null,
  query: null,
  pathname: '/',
  path: '/',
  href: 'http://127.0.0.1:8002/' }
```

**Reason**: `url.parse` return `host` with port information, but `http.request` using `host` only a domain name or ip, so it does not work. It would be better using `hostname` instead of `host`. 

In addition, if not apply this patch, it will work fine with add `host` and `port` to `config.js`, eg:
```
auth: {
    type: 'http_basic_auth',
    require_always: true,
    url: 'http://127.0.0.1:8002/',
    host: '127.0.0.1',
    port: 8002
    realm: '@xxx.com'
}
```