### PR TITLE
Add setup_queries_auth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ monitor: {
 ## Authentication
 
 Shib have authentication to log who execute queries and to control accesses:
+setup_queries_auth option means to specify queries executed before main query when authentication is required.
 
 ```js
 var servers = exports.servers = {
@@ -435,6 +436,7 @@ var servers = exports.servers = {
   fetch_lines: 1000,   // lines per fetch in shib
   query_timeout: null, // shib waits queries forever
   setup_queries: [],
+  setup_queries_auth: ["set hive.mapred.mode=strict"],
   storage: {
     datadir: './var'
   },

--- a/app.js
+++ b/app.js
@@ -307,7 +307,7 @@ app.post('/execute', function(req, res){
     shib.logger().info('User try to execute query', {username: userdata.username, query: querystring});
   }
 
-  client.createQuery(engineLabel, dbname, querystring, scheduled, function(err, query){
+  client.createQuery(engineLabel, dbname, querystring, scheduled, userdata, function(err, query){
     if (err) {
       if (err.error) {
         err = err.error;

--- a/lib/shib/client.js
+++ b/lib/shib/client.js
@@ -20,6 +20,7 @@ var Client = exports.Client = function(args, logger, credential){
    *   fetch_lines: 1000,
    *   query_timeout: null,
    *   setup_queries: [],
+   *   setup_queries_auth: [],
    *   default_database: 'default',
    *
    * these may be overwritten by each engine configurations
@@ -28,6 +29,7 @@ var Client = exports.Client = function(args, logger, credential){
   this._default_fetch_lines = this._conf.fetch_lines || FETCH_LINES_DEFAULT;
   this._default_query_timeout = this._conf.query_timeout || null;
   this._default_setup_queries = this._conf.setup_queries || [];
+  this._default_setup_queries_auth = this._conf.setup_queries_auth || [];
   this._default_default_database = this._conf.default_database || 'default';
 
   this._default_engine_label = undefined;
@@ -145,6 +147,7 @@ Client.prototype.engine = function(label){
     query_timeout: this._default_query_timeout,
     fetch_lines: this._default_fetch_lines,
     setup_queries: this._default_setup_queries,
+    setup_queries_auth: this._default_setup_queries_auth,
     auth_credential: this.auth_credential
   };
 
@@ -154,6 +157,8 @@ Client.prototype.engine = function(label){
     options.query_timeout = executer_conf.query_timeout;
   if (executer_conf.setup_queries)
     options.setup_queries = executer_conf.setup_queries;
+  if (executer_conf.setup_queries_auth)
+    options.setup_queries_auth = executer_conf.setup_queries_auth;
 
   if (! executer_conf.default_database)
     executer_conf.default_database = this._default_default_database;
@@ -213,14 +218,20 @@ Client.prototype.updateQuery = function(query, callback) {
   });
 };
 
-Client.prototype.createQuery = function(engineLabel, dbname, querystring, scheduled, callback){
+Client.prototype.createQuery = function(engineLabel, dbname, querystring, scheduled, userdata, callback){
   var client = this;
   var seed;
   var query;
   try {
     var rand = Math.floor(Math.random() * 10000);
     seed = (new Date()).toTimeString() + ";" + rand.toString(); // for queryid
-    query = new Query({querystring:querystring, engine: engineLabel, dbname: dbname, scheduled: scheduled, seed: seed});
+    var auth;
+    if(userdata) {
+      auth = true;
+    } else {
+      auth = false;
+    }
+    query = new Query({querystring:querystring, engine: engineLabel, dbname: dbname, scheduled: scheduled, seed: seed, auth: auth});
   }
   catch (e) {
     error_callback('createQuery catch', client, callback, e);
@@ -480,7 +491,7 @@ Client.prototype.execute = function(query, args){
       args.error();
     return;
   }
-  engine.execute(query.queryid, query.dbname, query.composed(), {
+  engine.execute(query.queryid, query.dbname, query.composed(), query.auth, {
     stopcheck: args.stopCheck,
     stop: args.stop,
     complete: function(err){

--- a/lib/shib/engine.js
+++ b/lib/shib/engine.js
@@ -20,6 +20,7 @@ var Engine = exports.Engine = function(label, executer_conf, monitor_conf, optio
   // this._executer = dummyengine.Executer();
   this._query_timeout = options.query_timeout;
   this._setup_queries = options.setup_queries;
+  this._setup_queries_auth = options.setup_queries_auth;
   this._fetch_lines = options.fetch_lines;
   this._auth_credential = options.auth_credential;
   this._executer = null;
@@ -219,7 +220,7 @@ options: {
   success: function(){} // without fetchNum, fetchAll() -> success_callback(result_rows) (or callback(null,result_rows) )
 }
  */
-Engine.prototype.execute = function(queryid, dbname, query, options) {
+Engine.prototype.execute = function(queryid, dbname, query, auth, options) {
   var self = this;
 
   var executer = this._executer;
@@ -241,6 +242,9 @@ Engine.prototype.execute = function(queryid, dbname, query, options) {
   var timeout_callback = options.timeout || error_callback || function(err){};
 
   var setups = this._setup_queries || [];
+  if(auth) {
+    setups = setups.concat(this._setup_queries_auth)
+  }
   var fetchnum = this._fetch_lines;
 
   var fetch_callback = null;

--- a/lib/shib/index.js
+++ b/lib/shib/index.js
@@ -7,6 +7,7 @@ var default_configs = {
   fetch_lines: 1000,
   query_timeout: null,
   setup_queries: [],
+  setup_queries_auth: [],
   storage: {
     datadir: './var'
   },
@@ -22,7 +23,8 @@ var default_configs = {
         support_database: true,
         default_database: 'default',
         query_timeout: null,
-        setup_queries: []
+        setup_queries: [],
+        setup_queries_auth: []
       },
       monitor: null
     }

--- a/lib/shib/query.js
+++ b/lib/shib/query.js
@@ -38,6 +38,7 @@ var Query = exports.Query = function(args){
 
   this.engine = args.engine;
   this.dbname = args.dbname;
+  this.auth = args.auth;
 
   this.state = args.state || STATE_RUNNING;
 


### PR DESCRIPTION
When authentication is required, queries are executed before main query.

Good example is "set hive.mapred.mode=strict;"

I don't want to use setup_queries option because I consider the confluence of batch query.