### PR TITLE
Add max_result_file_byte_size option to avoid a huge result file

### DIFF
--- a/lib/shib/client.js
+++ b/lib/shib/client.js
@@ -21,6 +21,7 @@ var Client = exports.Client = function(args, logger, credential){
    *   query_timeout: null,
    *   setup_queries: [],
    *   setup_queries_auth: [],
+   *   max_result_file_byte_size: null,
    *   default_database: 'default',
    *
    * these may be overwritten by each engine configurations
@@ -30,6 +31,7 @@ var Client = exports.Client = function(args, logger, credential){
   this._default_query_timeout = this._conf.query_timeout || null;
   this._default_setup_queries = this._conf.setup_queries || [];
   this._default_setup_queries_auth = this._conf.setup_queries_auth || [];
+  this._default_max_result_file_byte_size = this._conf.max_result_file_byte_size || null;
   this._default_default_database = this._conf.default_database || 'default';
 
   this._default_engine_label = undefined;
@@ -556,7 +558,11 @@ Client.prototype.execute = function(query, args){
         }
         resultLines += rows.length;
         resultBytes += rows.reduce(function(prev,v){return prev + v.length + 1;}, 0);
-        cb();
+        if (this._default_max_result_file_byte_size != null && resultBytes > this._default_max_result_file_byte_size) {
+          cb({message:"Result file size exceeds " + this._default_max_result_file_byte_size + " bytes."})
+        } else {
+          cb();
+        }
       });
     }
   });

--- a/lib/shib/engine.js
+++ b/lib/shib/engine.js
@@ -326,7 +326,7 @@ Engine.prototype.execute = function(queryid, dbname, query, auth, options) {
           if (err) {
             has_errors = true;
             self.logger.warn("fetch killed with upper layer error", {err: err});
-            complete_callback({message:"Fetching exits with errors"});
+            complete_callback({message:"Fetching exits with errors. " + err.message});
             return;
           }
 

--- a/lib/shib/index.js
+++ b/lib/shib/index.js
@@ -8,6 +8,7 @@ var default_configs = {
   query_timeout: null,
   setup_queries: [],
   setup_queries_auth: [],
+  max_result_file_byte_size: null,
   storage: {
     datadir: './var'
   },


### PR DESCRIPTION
for example, if user sets config.js, 
```
max_result_file_byte_size: 1024, //1kb
```

the following is an error message example.
```
Result:Fetching exits with errors. Result file size exceeds 1024 bytes.
```