### PR TITLE
Don’t use execute(arg, callback) in presto-client-node because presto 0.161 removed /v1/execute api

### DIFF
--- a/lib/shib/engines/presto/index.js
+++ b/lib/shib/engines/presto/index.js
@@ -53,8 +53,21 @@ Executer.prototype.setup = function(setups, callback){
   callback(null);
 };
 
+Executer.prototype.options = function(query, schema, func){
+  var options = {
+    query:  query,
+    schema: schema,
+    state:   function(error, query_id, stats){ /*console.log({message:"status changed", id:query_id, stats:stats});*/ },
+    columns: function(error, data){ /*console.log({resultColumns: data});*/ },
+    data:    function(error, data, columns, stats){ func(error, data) },
+    success: function(error, stats){},
+    error:   function(error){console.log(error);}
+  };
+  return options
+};
+
 Executer.prototype.databases = function(callback){
-  this._client.execute({query:'show schemas', schema:'dummy'}, function(err, data){
+  this._client.execute(this.options('show schemas', 'dummy', function(err, data){
     if (err) { callback(err); return; }
     // [ [ 'default' ], [ 'information_schema' ], [ 'sys' ] ]
     // database names may be always string...
@@ -65,32 +78,33 @@ Executer.prototype.databases = function(callback){
         results.push(dbname);
     });
     callback(null, results);
-  });
+  }));
 };
 
 Executer.prototype.tables = function(dbname, callback){
-  this._client.execute({query: 'show tables', schema: dbname}, function(err, data){
+  this._client.execute(this.options('show tables', dbname, function(err, data){
     if (err) { callback(err); return; }
     // [ [ 'table1' ], [ 'table2' ], ... ]
     // table names may be always string...
     var results = data.map(function(row){ return row[0]; });
     callback(null, results);
-  });
+  }));
 };
 
 Executer.prototype.partitions = function(dbname, tablename, callback){
   var client = this._client;
   var show_partitions_query = 'show partitions from ' + tablename;
-  client.execute({query: 'show columns from ' + tablename, schema: dbname}, function(err, data){
+  var options_ = this.options;
+  client.execute(options_('show columns from ' + tablename, dbname, function(err, data){
     if (err) { callback(err); return; }
     // [ [ 'fieldname', 'typename', boolean_null, boolean_partition_key ], ... ]
     // partition names may be always string...
     var partitionKeys = [];
     data.forEach(function(row){
-      if (row[3])
+      if (row[2])
         partitionKeys.push(row[0]);
     });
-    client.execute({query: show_partitions_query, schema: dbname}, function(err, data){
+    client.execute(options_(show_partitions_query, dbname, function(err, data){
       if (err) { callback(err); return; }
       // data: [ [ 'partkey1_value', 'partkey2_value' ], ... ]
       // expected: ['f1=va1/f2=vb1', 'f1=va1/f2=vb2']
@@ -100,20 +114,20 @@ Executer.prototype.partitions = function(dbname, tablename, callback){
         results.push( part );
       });
       callback(null, results);
-    });
-  });
+    }));
+  }));
 };
 
 Executer.prototype.describe = function(dbname, tablename, callback){
   // presto "show columns from ..." does not return column comments in hive metastore
   // schema info members may not include numeric values
-  this._client.execute({query:'show columns from ' + tablename, schema: dbname}, function(err, data){
+  this._client.execute(this.options('show columns from ' + tablename, dbname, function(err, data){
     if (err) { callback(err); return; }
     // data:     [ [ 'fieldname', 'typename', boolean_null, boolean_partition_key ], ... ]
     // expected: [ [ 'fieldname', 'type', 'comment' ], ... ]
-    var results = data.map(function(row){ return [ row[0], row[1], (row[3] ? 'partition key' : '') ]; });
+    var results = data.map(function(row){ return [ row[0], row[1], (row[2] ? 'partition key' : '') ]; });
     callback(null, results);
-  });
+  }));
 };
 
 Executer.prototype.execute = function(jobname, dbname, query, callback){


### PR DESCRIPTION
https://prestodb.io/docs/current/release/release-0.161.html